### PR TITLE
Fixed logic for DDF, added more tests, bumped version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "pypy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "pypy"
 
 script:
   - python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read(fname):
 
 setup(
     name="ondelta",
-    version="0.3.0",
+    version="0.4.0",
     author="Adam Haney",
     author_email="adam.haney@getbellhops.com",
     description=DESCRIPTION,
@@ -39,10 +39,15 @@ setup(
     long_description=read('README.md'),
     dependency_links=[],
     install_requires=[
-        'django'
+        'django>=1.5'
     ],
     classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Web Environment',
+        'Framework :: Django',
         'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
@@ -50,5 +55,8 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Internet :: WWW/HTTP',
     ],
 )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,8 @@
 Django==1.7.4
+django-dynamic-fixture==1.8.1
 django-nose==1.3
 flake8==2.3.0
-ipdbplugin==1.4
+ipdbplugin==1.4.1
 ipython==2.4.1
 mock==1.0.1
-nose==1.3.0
+nose==1.3.4

--- a/testproject/testproject/testapp/tests.py
+++ b/testproject/testproject/testapp/tests.py
@@ -4,6 +4,8 @@ from mock import Mock, patch, call
 
 from django.test import TestCase
 
+from django_dynamic_fixture import G, N
+
 from .models import Foo, Bar
 
 
@@ -70,6 +72,52 @@ class OndeltaMethodCallUnitTests(TestCase):
                 ),
             ]
         )
+
+
+class WorkFlowTests(TestCase):
+
+    def setUp(self):
+        self.foo = G(Foo, char_field='foo')
+
+    def test_get_from_db(self):
+        foo = Foo.objects.get(char_field='foo')
+        foo.char_field = 'bar'
+        foo.save()
+        foo.char_field = 'baz'
+        foo.save()
+        self.assertEqual(foo.char_field_delta_count, 2)
+
+    def test_create(self):
+        foo = Foo.objects.create(char_field='foo')
+        foo.char_field = 'bar'
+        foo.save()
+        foo.char_field = 'baz'
+        foo.save()
+        self.assertEqual(foo.char_field_delta_count, 2)
+
+    def test_construct(self):
+        foo = Foo(char_field='foo')
+        foo.char_field = 'bar'
+        foo.save()
+        foo.char_field = 'baz'
+        foo.save()
+        self.assertEqual(foo.char_field_delta_count, 1)
+
+    def test_g(self):
+        foo = G(Foo, char_field='foo')
+        foo.char_field = 'bar'
+        foo.save()
+        foo.char_field = 'baz'
+        foo.save()
+        self.assertEqual(foo.char_field_delta_count, 2)
+
+    def test_n(self):
+        foo = N(Foo, char_field='foo')
+        foo.char_field = 'bar'
+        foo.save()
+        foo.char_field = 'baz'
+        foo.save()
+        self.assertEqual(foo.char_field_delta_count, 1)
 
 
 class SaveChangesMadeByOndeltaMethodTests(TestCase):


### PR DESCRIPTION
- fixed a bug in the snapshot logic that was failing with objects created by `django-dynamic-fixture`
- added `django-dynamic-fixture` to testing requirements
- added new tests to make sure various methods of object creation work
- added enforced Django >= 1.5 requirement (needed for the `@cached_property` decorator)
- added `pypy` to Travis testing, removed python 3.2
- bumped version number to `0.4.0`