### PR TITLE
Adding a post ondelta signal + tests

### DIFF
--- a/ondelta/models.py
+++ b/ondelta/models.py
@@ -6,6 +6,8 @@ import logging
 from django.db import models
 from django.utils.functional import cached_property
 
+from .signals import post_ondelta_signal
+
 logger = logging.getLogger('ondelta')
 
 
@@ -107,4 +109,5 @@ class OnDeltaMixin(models.Model):
             fields_changed = self._ondelta_get_differences()
             if fields_changed:
                 self._ondelta_dispatch_notifications(fields_changed)
+                post_ondelta_signal.send(sender=self.__class__, fields_changed=fields_changed, instance=self)
         return super_return

--- a/ondelta/signals.py
+++ b/ondelta/signals.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from django.dispatch import Signal
+
+post_ondelta_signal = Signal(providing_args=['fields_changed', 'instance'])

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read(fname):
 
 setup(
     name="ondelta",
-    version="0.5.0",
+    version="0.6.0",
     author="Adam Haney",
     author_email="adam.haney@getbellhops.com",
     description=DESCRIPTION,

--- a/testproject/testproject/testapp/tests.py
+++ b/testproject/testproject/testapp/tests.py
@@ -183,6 +183,33 @@ class SaveChangesMadeByOndeltaMethodTests(TestCase):
         )
 
 
+class PostOnDeltaSignalTests(TestCase):
+
+    def setUp(self):
+        self.foo = Foo.objects.create(char_field='original_value')
+
+    @patch('ondelta.signals.post_ondelta_signal.send')
+    def test_signal_generated_with_correct_kwargs_on_any_delta(self, signal_mock):
+        signal_mock.reset_mock()
+        self.foo.char_field='second_value'
+        self.foo.save()
+        signal_mock.assert_called_once_with(
+            fields_changed={
+                'char_field': {
+                    'old': 'original_value',
+                    'new': 'second_value',
+                }
+            },
+            instance=self.foo, 
+            sender=Foo,
+        )
+
+    @patch('ondelta.signals.post_ondelta_signal.send')
+    def test_signal_not_generated_when_no_changes(self, signal_mock):
+        self.foo.save()
+        self.assertFalse(signal_mock.called)
+
+
 class SupportedRelatedFieldTypeTests(TestCase):
 
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist = py27,py34
 
 [testenv]
 deps = -rtest_requirements.txt
-commands=cd testproject && python manage.py test
+commands=/usr/bin/cd testproject && python manage.py test


### PR DESCRIPTION
## Purpose
Sometimes, it would be nice to have the ability to listen for field changes outside of the model that has been updated. The normal Django `post_save` signal only provides information about `updated_fields` if that information was explicitly supplied during the save, so signal handlers that do work in response to  certain field updates are left either doing that work on all updates or none. 

This PR attempts to expand the capabilities of django-ondelta by providing a new signal emission during the ondelta process. This signal carries with it information on the fields that have been updated, as well as a reference to the instance itself. 